### PR TITLE
RVIZ and joint publisher implementation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -96,10 +96,6 @@ RUN apt-get update && apt-get install -y \
     ros-humble-ros-gz-sim \
     ros-humble-ros-ign-bridge \
     \
-    # ---------------- GAZEBO PLUGINS ----------------
-    # GUI plugin
-    libgz-gui6 \
-    \
     # ---------------- HARDWARE / NETWORK ----------------
     # USB utilities
     usbutils \
@@ -119,9 +115,10 @@ RUN apt-get update && apt-get install -y \
     # ---------------- MISC / UTILITIES ----------------
     lsb-release \
     gnupg \
+    btop \
     wget \
     zstd \
-    vim\
+    vim \
     && rm -rf /var/lib/apt/lists/*
 
 
@@ -159,6 +156,17 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/p
 # Install Gazebo Ignition Fortress (simulation environment)
 RUN apt-get update && apt-get install -y ignition-fortress
 
+# Install Gazebo plugins
+RUN apt-get update && apt-get install -y \
+    libgz-cmake3-dev \
+    libgz-gui6 \
+    libgz-plugin2-dev \
+    libgz-common5-dev \
+    libgz-sim7-dev \
+    ros-humble-rviz2 \
+    ros-humble-xacro \
+    ros-humble-joint-state-publisher-gui \
+    && rm -rf /var/lib/apt/lists/*
 
 # --------------------------------------------------------------------------------------------
 # DISPLAY / VNC CONFIGURATION
@@ -192,22 +200,8 @@ RUN useradd trickfire \
 # Copy custom bash configuration for the user
 COPY .devcontainer/trickfire.bashrc /home/trickfire/.bashrc
 
-#---------------------------------------------------------------------------------------------
-#SIMULATION SETUP
-#---------------------------------------------------------------------------------------------
-
+# Copy robot workspace into correct location in container
 COPY robot-sim/ /home/trickfire/gazebo-simulations/src/
-
-RUN apt-get update && apt-get install -y \
-    libgz-cmake3-dev \
-    libgz-plugin2-dev \
-    libgz-common5-dev \
-    libgz-sim7-dev \
-    ros-humble-rviz2 \
-    ros-humble-xacro \
-    ros-humble-joint-state-publisher-gui
-
-
 
 RUN echo "trickfire ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/user
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     // FORMATTING
     "[dockerfile]": {
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "ms-vscode-remote.remote-containers"
+        "editor.defaultFormatter": "ms-azuretools.vscode-containers"
     },
     "[xml]": {
         "editor.formatOnSave": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,22 @@
 {
+    // FORMATTING
+    "[dockerfile]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "ms-vscode-remote.remote-containers"
+    },
+    "[xml]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "DotJoshJohnson.xml"
+    },
+    "[python]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.defaultColorDecorators": "never",
+        "editor.formatOnType": true,
+        "editor.wordBasedSuggestions": "off"
+    },
+
     // VSCODE
     "remote.autoForwardPorts": false,
     "files.associations": {
@@ -19,5 +37,5 @@
     "python.analysis.extraPaths": [
         "/opt/ros/humble/lib/python3.10/site-packages",
         "/opt/ros/humble/local/lib/python3.10/dist-packages"
-    ]
+    ],
 }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Gazebo Simulations
 
-> This repository contains Gazebo simulations for the drivebase, arm, and autonomous.
+This repository contains [Gazebo Fortress](https://gazebosim.org/docs/fortress/install/) simulations for Trickfire’s robot subsystems, including the drivebase, arm, and autonomous systems. The project uses [ROS 2 Humble](https://docs.ros.org/en/humble/index.html) for robot code and runs entirely inside a Docker container, including the codebase and Gazebo GUI.
 
 ## How to run Gazebo
 
 > [!NOTE]
-> If you have a device with X11 set up like Windows with WSL installed or Linux, first look [here](#systems-with-x11)
+> If you have a device with X11 set up like Windows with WSL installed or Linux, first look [here](#systems-with-x11). If you do not mind installing an app, you can look [here](#vnc-viewer), although it is optional.
 
 1. Clone this repo
 2. Make sure you have the `ms-vscode-remote.remote-containers` VsCode extension installed.
@@ -19,28 +19,6 @@
 ign gazebo empty.sdf
 ```
 
-<details>
-<summary><h3>Additional information</h3></summary>
-
-### VNC Viewer
-
-If you don't mind installing an app, there is a better way to open up Gazebo on Mac, that allows passing through key combos like `alt-tab` and simillar. You can install the app [from here](https://www.realvnc.com/en/connect/download/viewer/) or using Homebrew like this: `brew install --cask vnc-viewer` To make the app work skip the 6th and 7th step in the directions and instead open this app. Create a new connection by doing `CTRL+N` or `CMD+N` depending on OS, and to adress paste this:
-
-```ip
-localhost:5900
-```
-
-You're going to get a popup informing you that the connection is not secure. You do not have to worry about this as it is run locally.
-
-Note that if you're using a system with `X11` provided, this does nothing better than what you already have. For people using the `noVNC` in the browser this is optional, but provides more functionality.
-
-
-### Systems with X11
-
-On systems that provide X11 (like Linux and WSL), GUI forwarding is typically built-in. You can usually skip steps 5 and 6 and just run Gazebo — a Gazebo window should appear automatically. The `start_x_server.sh` script is not needed in these cases, since these systems already handle the display binding (for example, WSL binds to display :0). For more details about WSL gui-apps, you can check [here](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps).
-
-</details>
-
 ## How to run simulation
 
 Once you launch the `devcontainer`, set up your display environment and verified Gazebo runs, you're ready to start the simulation. There is a script that will build the ROS files and launch the arm simulation (it is the only one we have right now) using our launch file. You can call it using this command:
@@ -53,3 +31,24 @@ After the script logs `[create-2] [INFO] ... [ros_gz_sim]: OK creation of entity
 
 >[!TIP]
 >For more information and troubleshooting tips go look at the [simulation README](./robot-sim/README.md).
+
+---
+
+## Additional information
+
+### Systems with X11
+
+On systems that provide X11 (like Linux and WSL), GUI forwarding is typically built-in. You can usually skip steps 5 and 6 and just run Gazebo — a Gazebo window should appear automatically. The `start_x_server.sh` script is not needed in these cases, since these systems already handle the display binding (for example, WSL binds to display :0). For more details about WSL gui-apps, you can check [here](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps).
+
+### VNC Viewer
+
+> [!NOTE]
+> If you're using a system with `X11` provided, this does nothing better than what you already have. For people using the `noVNC` in the browser this is optional, but provides more functionality.
+
+If you don't mind installing an app, there is a better way to open up Gazebo on Mac, that allows passing through key combos like `alt-tab` and simillar. You can install the app [from here](https://www.realvnc.com/en/connect/download/viewer/) or using Homebrew like this: `brew install --cask vnc-viewer` To make the app work skip the 6th and 7th step in the directions and instead open this app. Create a new connection by doing `CTRL+N` or `CMD+N` depending on OS, and to adress paste this:
+
+```ip
+localhost:5900
+```
+
+You're going to get a popup informing you that the connection is not secure. You do not have to worry about this as it is run locally.

--- a/README.md
+++ b/README.md
@@ -19,17 +19,37 @@
 ign gazebo empty.sdf
 ```
 
+<details>
+<summary><h3>Additional information</h3></summary>
+
+### VNC Viewer
+
+If you don't mind installing an app, there is a better way to open up Gazebo on Mac, that allows passing through key combos like `alt-tab` and simillar. You can install the app [from here](https://www.realvnc.com/en/connect/download/viewer/) or using Homebrew like this: `brew install --cask vnc-viewer` To make the app work skip the 6th and 7th step in the directions and instead open this app. Create a new connection by doing `CTRL+N` or `CMD+N` depending on OS, and to adress paste this:
+
+```ip
+localhost:5900
+```
+
+You're going to get a popup informing you that the connection is not secure. You do not have to worry about this as it is run locally.
+
+Note that if you're using a system with `X11` provided, this does nothing better than what you already have. For people using the `noVNC` in the browser this is optional, but provides more functionality.
+
+
 ### Systems with X11
 
 On systems that provide X11 (like Linux and WSL), GUI forwarding is typically built-in. You can usually skip steps 5 and 6 and just run Gazebo — a Gazebo window should appear automatically. The `start_x_server.sh` script is not needed in these cases, since these systems already handle the display binding (for example, WSL binds to display :0). For more details about WSL gui-apps, you can check [here](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps).
 
+</details>
 
 ## How to run simulation
 
-Once you launch the docker and set up your x-server environment container run this bash script:
+Once you launch the `devcontainer`, set up your display environment and verified Gazebo runs, you're ready to start the simulation. There is a script that will build the ROS files and launch the arm simulation (it is the only one we have right now) using our launch file. You can call it using this command:
 
 ```bash
-./build-ros2-sim.sh
+./scripts/build_ros2_sim.sh
 ```
 
-Then 2 windows should appear, one will contain the model we are currently using for testing, a default mini rover, and the second a rvis2 window which is used to visualize PUB-SUB communication within ROS. For more info check out the [simulation README](./robot-sim/README.md).
+After the script logs `[create-2] [INFO] ... [ros_gz_sim]: OK creation of entity.` the simulation launched. You can go to your Gazebo window and you should see the arm model.
+
+>[!TIP]
+>For more information and troubleshooting tips go look at the [simulation README](./robot-sim/README.md).

--- a/robot-sim/launch_files/config/arm.rviz
+++ b/robot-sim/launch_files/config/arm.rviz
@@ -1,0 +1,189 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /RobotModel1
+      Splitter Ratio: 0.4676470458507538
+    Tree Height: 410
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        bicep_actuator:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        forearm:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        gripper_assembly:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        joint:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        shoulder_assembly:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: RobotModel
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 2.1567115783691406
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.21136832237243652
+        Y: -0.11549606919288635
+        Z: 0.182855486869812
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.7203978896141052
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 5.173583507537842
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 701
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000015600000223fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b00000223000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010000000223fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003b00000223000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000005000000003efc0100000002fb0000000800540069006d00650100000000000005000000025300fffffffb0000000800540069006d006501000000000000045000000000000000000000029e0000022300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1280
+  X: 0
+  Y: 0

--- a/robot-sim/launch_files/launch/arm.launch.py
+++ b/robot-sim/launch_files/launch/arm.launch.py
@@ -6,16 +6,11 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-
-
-pkg_project_bringup = get_package_share_directory("launch_files")
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 
 
 def log(log_msg):
@@ -26,27 +21,43 @@ def log(log_msg):
 def generate_launch_description():
     """ROS launch method, must have this name"""
 
-    # Locate directory of the package containing world and model files
-    pkg_models_and_worlds = get_package_share_directory("models_and_worlds")
+    # ----------------------------------------------
+    # Locate project package directories
+    # ----------------------------------------------
 
-    # Locate directory of the package containing the Gazebo GUI config
+    # World and model files
+    pkg_models_and_worlds = get_package_share_directory("models_and_worlds")
+    # Gazebo GUI config
     pkg_gz_code = get_package_share_directory("gazebo_code")
+    # RVIZ and bridge configs
+    pkg_project_bringup = get_package_share_directory("launch_files")
+
+    # ----------------------------------------------
+    # Build paths to required files
+    # ----------------------------------------------
 
     # Build the path to the model URDF file
     urdf_file = os.path.join(pkg_models_and_worlds, "models", "arm", "arm.urdf")
-    log("Model file: " + urdf_file)
+    log("URDF model file: " + urdf_file)
     with open(urdf_file, "r", encoding="UTF-8") as infp:
         robot_desc = infp.read()
 
-    # Build the path to the world file the arm will be in
+    # Build the path to Gazebo world file
     world_file = os.path.join(pkg_models_and_worlds, "worlds", "arm_world.sdf")
-    log("World file: " + world_file)
+    log("Gazebo world file: " + world_file)
 
-    # Build the path to the Gazebo GUI config
+    # Build the path to Gazebo GUI config
     gz_gui_config_file = os.path.join(pkg_gz_code, "gui", "gui.config")
-    log("GUI config file: " + gz_gui_config_file)
+    log("Gazebo GUI config file: " + gz_gui_config_file)
 
-    # Gazebo simulation settings
+    # Build the path to RVIZ config
+    rviz_config_file = os.path.join(pkg_project_bringup, "config", "arm.rviz")
+    log("RVIZ config file: " + rviz_config_file)
+
+    # ----------------------------------------------
+    # Gazebo launch arguments
+    # ----------------------------------------------
+
     gz_sim = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
@@ -57,6 +68,10 @@ def generate_launch_description():
             "gz_args": " ".join(["-r", world_file, "--gui-config", gz_gui_config_file])
         }.items(),
     )
+
+    # ----------------------------------------------
+    # Action nodes
+    # ----------------------------------------------
 
     # Uses the ros_gz_sim 'create' node to send the URDF string to
     # Gazebo’s spawn service and place the robot at a given pose
@@ -87,26 +102,54 @@ def generate_launch_description():
         parameters=[{"robot_description": robot_desc}],
     )
 
-
+    # GUI for tweaking joint values
     joint_state_publisher_gui = Node(
-        package='joint_state_publisher_gui',
-        executable='joint_state_publisher_gui',
-        name='joint_state_publisher_gui',
-        arguments=[
-           urdf_file 
-        ],
-        output=['screen']
+        package="joint_state_publisher_gui",
+        executable="joint_state_publisher_gui",
+        name="joint_state_publisher_gui",
+        arguments=[urdf_file],
+        output=["screen"],
     )
 
+    # RVIZ
+    rviz = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        arguments=[
+            "-d",
+            rviz_config_file,
+        ],
+        condition=IfCondition(LaunchConfiguration("rviz")),
+    )
 
-
-
-
-
-
-
-
+    # Bridge ROS topics and Gazebo messages
+    bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        parameters=[
+            {
+                "config_file": os.path.join(
+                    pkg_project_bringup, "config", "ros_gz_example_bridge.yaml"
+                ),
+                "qos_overrides./tf_static.publisher.durability": "transient_local",
+            }
+        ],
+        output="screen",
+    )
 
     # Return the final launch description
     # Will be executed in order (order matters)
-    return LaunchDescription([gz_sim, spawn_robot, robot_state_publisher, joint_state_publisher_gui])
+    return LaunchDescription(
+        [
+            gz_sim,
+            DeclareLaunchArgument(
+                "rviz", default_value="true", description="Open RViz."
+            ),
+            bridge,
+            spawn_robot,
+            robot_state_publisher,
+            joint_state_publisher_gui,
+            rviz,
+        ]
+    )

--- a/robot-sim/models_and_worlds/models/arm/arm.urdf
+++ b/robot-sim/models_and_worlds/models/arm/arm.urdf
@@ -2,6 +2,15 @@
 <!-- Generated using onshape-to-robot -->
 <!-- Onshape https://cad.onshape.com/documents/9b05a4dfb79241a5b295b397/w/d00f3086da43b93d9c689413/e/4de2423405201a00f735c419 -->
 <robot name="arm">
+    <!-- Root base link -->
+    <link name="base_link"/>
+
+    <joint name="base_to_shoulder" type="fixed">
+        <parent link="base_link"/>
+        <child link="shoulder_assembly"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+    </joint>
+
     <!-- Link shoulder_assembly -->
     <link name="shoulder_assembly">
         <inertial>

--- a/scripts/build_ros2_sim.sh
+++ b/scripts/build_ros2_sim.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 
 # --------------------------------------------------------------------------------------------
-# build-ros2-sim.sh
+# build_ros2_sim.sh
 # --------------------------------------------------------------------------------------------
 # Builds the ROS 2 Gazebo simulation workspace, sets up the environment,
 # registers custom Gazebo models, and launches the ROS2 robot simulation.
 # --------------------------------------------------------------------------------------------
 
-# Checkout Sim template folder
 cd /home/trickfire/gazebo-simulations/robot-sim || exit 1
 
-# Build all of the folders Within our Folder
+# Build our robot files using the ROS build tool
 colcon build --cmake-args -DBUILD_TESTING=ON
 
-# Give setup script executable perms
+# Give generated ROS setup script executable perms
 chmod a+x install/setup.bash
 
 # Source our newly build dependencies


### PR DESCRIPTION
## Changes

- Made RVIZ work with joint publisher
- Added RVIZ launch to the arm.launch file
- Added an RVIZ config file into 
- Improved launch script logs and comments
- Added btop (computer resources monitor)
- Moved Gazebo `apt-get` call for installing plugins into it's correct section in the Dockerfile
- Added a base rigid joint to the `arm.urdf` file for RVIZ to have a base joint
- Added formatter settings to `vscode`, `python`, `Dockerfile` and `xml` files, meaning configured default formatters, and added a `format-on-save` option to make sure all files are formatted at all times