### PR TITLE
Refactor: Migrate to per-subsystem ROS2 package structure

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -138,6 +138,8 @@ RUN pip3 install pyusb opencv-python
 # Update pydocstyle to avoid deprecation warnings during testing
 RUN pip3 install --upgrade pydocstyle
 
+# Install python linter
+RUN pip3 install ruff
 
 # --------------------------------------------------------------------------------------------
 # GAZEBO / SIMULATION SETUP

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,48 +1,57 @@
 // DOCUMENTATION: https://containers.dev/implementors/json_reference/
 {
-  "context": "../",
-  "dockerFile": "Dockerfile",
-  "containerUser": "trickfire",
-  "remoteUser": "trickfire",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/trickfire/${localWorkspaceFolderBasename},type=bind",
-  "workspaceFolder": "/home/trickfire/${localWorkspaceFolderBasename}",
-  "initializeCommand": ".devcontainer/launch.sh",
-  "postCreateCommand": "scripts/delete_ros_build_files.sh",
-  "forwardPorts": [6080, 5900],
-  "runArgs": [
-    "--privileged",
-    "--cap-add=SYS_PTRACE",
-    "--device=/dev",
-    "--security-opt",
-    "seccomp=unconfined",
-    "--env-file",
-    ".devcontainer/launch.env",
-    "-e",
-    "QT_X11_NO_MITSHM=1",
-    "-v",
-    "/tmp/.X11-unix:/tmp/.X11-unix"
-  ],
-  "customizations": {
-    "vscode": {
-      "extensions": [
-        "ms-azuretools.vscode-docker",
-        "ms-python.python",
-        "ms-python.vscode-pylance",
-        "ms-python.pylint",
-        "ms-python.mypy-type-checker",
-        "ms-python.isort",
-        "ms-python.black-formatter",
-        "ms-vscode.cmake-tools",
-        "ms-vscode.cpptools",
-        "twxs.cmake",
-        "yzhang.markdown-all-in-one",
-        "Ranch-Hand-Robotics.rde-ros-2",
-        "ms-vscode.cpptools-extension-pack",
-        "smilerobotics.urdf",
-        "morningfrog.urdf-visualizer",
-        "misiekhardcore.stl-previewer",
-        "DotJoshJohnson.xml"
-      ]
+    "context": "../",
+    "dockerFile": "Dockerfile",
+    "containerUser": "trickfire",
+    "remoteUser": "trickfire",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/trickfire/${localWorkspaceFolderBasename},type=bind",
+    "workspaceFolder": "/home/trickfire/${localWorkspaceFolderBasename}",
+    "initializeCommand": ".devcontainer/launch.sh",
+    "postCreateCommand": "scripts/clean_build.sh",
+    "forwardPorts": [
+        6080,
+        5900
+    ],
+    "runArgs": [
+        "--privileged",
+        "--cap-add=SYS_PTRACE",
+        "--device=/dev",
+        "--security-opt",
+        "seccomp=unconfined",
+        "--env-file",
+        ".devcontainer/launch.env",
+        "-e",
+        "QT_X11_NO_MITSHM=1",
+        "-v",
+        "/tmp/.X11-unix:/tmp/.X11-unix"
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                // --- Python ---
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "charliermarsh.ruff",
+                "ms-python.pylint",
+                "ms-python.mypy-type-checker",
+                "ms-python.isort",
+                // --- C and C++ ---
+                "ms-vscode.cpptools",
+                "ms-vscode.cpptools-extension-pack",
+                "ms-vscode.cmake-tools",
+                "twxs.cmake",
+                // --- Robotics / ROS / URDF / meshes ---
+                "Ranch-Hand-Robotics.rde-ros-2",
+                "smilerobotics.urdf",
+                "morningfrog.urdf-visualizer",
+                "misiekhardcore.stl-previewer",
+                // --- Container ---
+                "ms-azuretools.vscode-docker",
+                // --- Formatters ---
+                "yzhang.markdown-all-in-one",
+                "DotJoshJohnson.xml",
+                "tamasfe.even-better-toml"
+            ]
+        }
     }
-  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,7 +50,8 @@
                 // --- Formatters ---
                 "yzhang.markdown-all-in-one",
                 "DotJoshJohnson.xml",
-                "tamasfe.even-better-toml"
+                "tamasfe.even-better-toml",
+                "github.vscode-github-actions"
             ]
         }
     }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run Ruff
+        run: ruff check --output-format=github .

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,20 +7,23 @@
         "editor.defaultFormatter": "ms-azuretools.vscode-containers",
         "editor.formatOnSave": true
     },
-
     "[xml]": {
         "editor.defaultFormatter": "DotJoshJohnson.xml",
         "editor.formatOnSave": true
     },
-
     "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.formatOnSave": true,
         "editor.formatOnType": true,
         "editor.wordBasedSuggestions": "off",
         "editor.defaultColorDecorators": "never",
-        "diffEditor.ignoreTrimWhitespace": false
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "always"
+        }
     },
+    "json.format.keepLines": true,
+    "json.format.enable": true,
 
 
     // ================================
@@ -29,20 +32,22 @@
 
     // To prevent vscode creating 20 random forwarded ports
     "remote.autoForwardPorts": false,
-
+    "editor.rulers": [
+        100
+    ],
     "files.associations": {
         "model.config": "xml"
     },
-
     "files.exclude": {
         "**/.git": true,
         "**/.hg": true,
         "**/.svn": true,
-        "**/.mypy_cache": true,
-        "**/__pycache__": true,
         "**/.DS_Store": true,
         "**/Thumbs.db": true,
-
+        // Python
+        "**/.ruff_cache": true,
+        "**/.mypy_cache": true,
+        "**/__pycache__": true,
         // Robot Dev extension stuff
         ".vscode/browse.vc.db": true,
         ".vscode/browse.vc.db-shm": true,
@@ -72,9 +77,8 @@
         "/opt/ros/humble/lib/python3.10/site-packages",
         "/opt/ros/humble/local/lib/python3.10/dist-packages"
     ],
-
     "python.autoComplete.extraPaths": [
         "/opt/ros/humble/lib/python3.10/site-packages",
         "/opt/ros/humble/local/lib/python3.10/dist-packages"
-    ]
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,15 +36,19 @@
         "model.config": "xml"
     },
     "files.exclude": {
+
+        // General
         "**/.git": true,
         "**/.hg": true,
         "**/.svn": true,
         "**/.DS_Store": true,
         "**/Thumbs.db": true,
+
         // Python
         "**/.ruff_cache": true,
         "**/.mypy_cache": true,
         "**/__pycache__": true,
+
         // Robot Dev extension stuff
         ".vscode/browse.vc.db": true,
         ".vscode/browse.vc.db-shm": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,9 +18,6 @@
         "editor.wordBasedSuggestions": "off",
         "editor.defaultColorDecorators": "never",
         "diffEditor.ignoreTrimWhitespace": false,
-        "editor.codeActionsOnSave": {
-            "source.organizeImports": "always"
-        }
     },
     "json.format.keepLines": true,
     "json.format.enable": true,

--- a/docs/move.md
+++ b/docs/move.md
@@ -1,3 +1,6 @@
+This is how to make the arm move. This is temporary so I don't forget, I'll improve it later.
+
+```bash
 ros2 topic pub /joint_trajectory_controller/joint_trajectory trajectory_msgs/msg/JointTrajectory "
 joint_names:
 - shoulder_1
@@ -9,3 +12,4 @@ points:
 - positions: [0.5, 0.5, 0.2, 0.0]
   time_from_start: {sec: 2}
 "
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.ruff]
+exclude = ["robot-sim/build", "robot-sim/log", "robot-sim/install"]
+
+line-length = 100
+indent-width = 4
+
+target-version = "py310"
+
+fixable = ["ALL"]
+unfixable = []
+
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+quote-style = "double"
+
+indent-style = "space"
+
+skip-magic-trailing-comma = false
+
+line-ending = "auto"
+
+docstring-code-format = true
+
+docstring-code-line-length = "dynamic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,9 @@ indent-width = 4
 
 target-version = "py310"
 
-fixable = ["ALL"]
-unfixable = []
-
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+lint.fixable = ["ALL"]
+lint.unfixable = []
+lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.format]
 quote-style = "double"

--- a/robot-sim/arm_bringup/launch/arm.launch.py
+++ b/robot-sim/arm_bringup/launch/arm.launch.py
@@ -9,11 +9,7 @@ from pathlib import Path
 import xacro
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import (
-    DeclareLaunchArgument,
-    IncludeLaunchDescription,
-    RegisterEventHandler,
-)
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, RegisterEventHandler
 from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -65,9 +61,7 @@ def generate_launch_description():
 
     gz_sim = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(
-                get_package_share_directory("ros_gz_sim"), "launch", "gz_sim.launch.py"
-            )
+            os.path.join(get_package_share_directory("ros_gz_sim"), "launch", "gz_sim.launch.py")
         ),
         launch_arguments={
             "gz_args": " ".join(["-r", world_file, "--gui-config", gz_gui_config])
@@ -168,9 +162,7 @@ def generate_launch_description():
             gz_sim,
             spawn_robot,
             robot_state_publisher,
-            DeclareLaunchArgument(
-                "rviz", default_value="true", description="Open RViz."
-            ),
+            DeclareLaunchArgument("rviz", default_value="true", description="Open RViz."),
             RegisterEventHandler(
                 event_handler=OnProcessExit(
                     target_action=spawn_robot,


### PR DESCRIPTION
## Summary

Removes the template-heavy monolithic workspace inherited from `ros_gz_example` and replaces it with a clean, scalable per-subsystem package layout. Cleans up hardcoded paths, switches URDF mesh references to use xacro, and overhauls the launch script.

## Why?

The previous structure was based on the `ros_gz_example` template and had several issues that would compound as more robot subsystems were added:

- All models, worlds, and launch files lived in two monolithic packages (`models_and_worlds`, `launch_files`), making it impossible to build or test a single subsystem in isolation
- Mesh paths in `arm.urdf` hardcoded the old package name, meaning any restructure would silently break the model
- The Gazebo controller plugin referenced an absolute path on a specific developer's machine
- Template robots (`diff_drive`, `rrbot`) and their associated launch files, configs, and world files were still present throughout the workspace
- `IGN_GAZEBO_RESOURCE_PATH` was used instead of the correct `GZ_SIM_RESOURCE_PATH`
- `launch_sim.sh` looked up launch files by hardcoded source path instead of through the installed ROS2 package index

---

## Changes

### Deleted

- `robot-sim/gazebo_code/` — entire package (template Gazebo systems, `diff_drive.sdf` world)
- `robot-sim/ros_configs/` — empty package, no longer needed
- `robot-sim/models_and_worlds/` — replaced by `arm_description/` and `sim_worlds/`
- `robot-sim/launch_files/` — replaced by `arm_bringup/`
- All `diff_drive` and `rrbot` launch files, configs, RViz files, and models

### Added: `arm_description/`

URDF and mesh assets for the arm, following the ROS2 `<robot>_description` convention.

```
arm_description/
├── urdf/
│   └── arm.urdf.xacro       # converted from arm.urdf; mesh path defined once via xacro property
├── meshes/
│   └── *.stl                # moved from models_and_worlds/models/arm/assets/
├── CMakeLists.txt
└── package.xml
```

Mesh references in the URDF changed from:

```xml
<mesh filename="package://models_and_worlds/models/arm/assets/part_1__7.stl"/>
```

to a single xacro property at the top of the file:

```xml
<xacro:property name="mesh_path" value="package://arm_description/meshes"/>
...
<mesh filename="${mesh_path}/part_1__7.stl"/>
```

The Gazebo controller plugin path is now passed in at launch time via a xacro arg instead of being hardcoded:

```xml
<!-- Before -->
<parameters>/home/trickfire/gazebo-simulations/robot-sim/launch_files/config/arm_controller.yaml</parameters>

<!-- After -->
<xacro:arg name="controller_config" default=""/>
<parameters>$(arg controller_config)</parameters>
```

### Added: `arm_bringup/`

Launch files and runtime configs for the arm, following the ROS2 `<robot>_bringup` convention.

```
arm_bringup/
├── launch/
│   └── arm_sim.launch.py    # resolves controller_config path via get_package_share_directory
├── config/
│   ├── arm.controller.yaml
│   └── arm.rviz
├── CMakeLists.txt
└── package.xml
```

### Added: `sim_worlds/`

Shared Gazebo environment files not tied to any specific robot.

```
sim_worlds/
├── worlds/
│   └── empty.world.sdf
├── gui/
│   ├── gui.config
│   └── gz_gui.xml
├── CMakeLists.txt
└── package.xml
```

`gui.config` moved here from `gazebo_code/gui/` since it is simulation-environment-level config, not robot-specific.

### Updated: `scripts/launch_sim.sh`

| Before                                        | After                                                                                     |
| --------------------------------------------- | ----------------------------------------------------------------------------------------- |
| Builds entire workspace                       | Builds only `<robot>_description`, `<robot>_bringup`, `sim_worlds` via `--packages-up-to` |
| Looks up launch file by hardcoded source path | Launches via `ros2 launch <robot>_bringup <robot>.launch.py`                          |
| Sets `IGN_GAZEBO_RESOURCE_PATH`               | Sets `GZ_SIM_RESOURCE_PATH` (correct Gazebo Fortress env var)                             |
| No pre-flight checks                          | Validates packages and launch file exist before building                                  |
| No flags                                      | Supports `--no-build` and `--build-only` flags                                            |

### Updated: `scripts/`

| Old name                    | New name                       |
| --------------------------- | ------------------------------ |
| `build_ros_sim.sh`          | `launch_sim.sh`                |
| `delete_ros_build_files.sh` | `clean_build.sh`               |
| `apt_enable_universe.sh`    | Moved to `docs/apt_sources.md` |
| `fix_urdf.py`               | Deleted to be reimplemented    |
| `move.sh`                   | Documented in `docs/move.md`   |

---

## Package structure going forward

When a new robot subsystem needs to be simulated, the pattern is:

```
robot-sim/
├── <subsystem>_description/    # URDF, meshes
├── <subsystem>_bringup/        # launch files, configs, RViz
└── sim_worlds/                 # shared worlds and GUI config (unchanged)
```

Build and launch with:

```bash
./scripts/launch_sim.sh <subsystem>
```

---

## Linting

Added [Ruff](https://docs.astral.sh/ruff/) as the python linter, instead of the Black Formatter. The configuration for it lives in the new `pyproject.toml` python configuration files in the repo root.

There is a new action ran on `push` or `pull-reqest` that will run **Ruff** to ensure our python code follows our standards.

---

## Other

Ignored all sorts of caches and temporary files from the file tree in VsCode. These are items currently ignored:

```json
// General
"**/.git": true,
"**/.hg": true,
"**/.svn": true,
"**/.DS_Store": true,
"**/Thumbs.db": true,

// Python
"**/.ruff_cache": true,
"**/.mypy_cache": true,
"**/__pycache__": true,

// ROS VsCode extension caches
".vscode/browse.vc.db": true,
".vscode/browse.vc.db-shm": true,
".vscode/browse.vc.db-wal": true
```
