### PR TITLE
Added genbot world-to-base link generation

### DIFF
--- a/.github/genbot/cli.py
+++ b/.github/genbot/cli.py
@@ -27,6 +27,14 @@ def main() -> None:
         action="store_true",
         help="Skip STL triangle-count reduction",
     )
+    create_parser.add_argument(
+        "--attach-to-world",
+        dest="attach_to_world",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Fix robot to world (arm/fixed base = yes, mobile chassis = no). "
+        "If omitted, prompts interactively.",
+    )
 
     # --- local ---
     local_parser = subparsers.add_parser(
@@ -53,6 +61,14 @@ def main() -> None:
         "--no-reduce",
         action="store_true",
         help="Skip STL triangle-count reduction",
+    )
+    local_parser.add_argument(
+        "--attach-to-world",
+        dest="attach_to_world",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Fix robot to world (arm/fixed base = yes, mobile chassis = no). "
+        "If omitted, prompts interactively.",
     )
 
     # --- raw ---

--- a/.github/genbot/commands.py
+++ b/.github/genbot/commands.py
@@ -21,6 +21,17 @@ from genbot.urdf import postprocess
 # ---------------------------------------------------------------------------
 
 
+def _prompt_yes_no(question: str) -> bool:
+    """Ask a yes/no question, return True for yes."""
+    while True:
+        answer = input(f"[genbot] {question} [y/n]: ").strip().lower()
+        if answer in ("y", "yes"):
+            return True
+        if answer in ("n", "no"):
+            return False
+        print("[genbot] Please answer y or n.")
+
+
 def _reduce_meshes(meshes_dir: Path, no_reduce: bool) -> None:
     """Reduce STL triangle counts in-place unless --no-reduce was passed"""
     if no_reduce:
@@ -32,7 +43,9 @@ def _reduce_meshes(meshes_dir: Path, no_reduce: bool) -> None:
     batch_process_directory(str(meshes_dir), str(meshes_dir))
 
 
-def _scaffold_packages(robot: str, urdf_path: Path, meshes_src: Path, out_dir: Path) -> None:
+def _scaffold_packages(
+    robot: str, urdf_path: Path, meshes_src: Path, out_dir: Path, world_base_link: bool = False
+) -> None:
     """Post-process URDF and write _description + _bringup packages"""
     if not meshes_src.exists():
         warn(f"Meshes directory {meshes_src} was not created")
@@ -40,7 +53,7 @@ def _scaffold_packages(robot: str, urdf_path: Path, meshes_src: Path, out_dir: P
         warn(f"Meshes directory {meshes_src} is empty")
 
     info("Post-processing URDF...")
-    geometry_urdf, control_xacro, joints, links = postprocess(urdf_path, robot)
+    geometry_urdf, control_xacro, joints, links = postprocess(urdf_path, robot, world_base_link)
 
     if joints:
         joint_names = [name for name, _, _ in joints]
@@ -84,15 +97,22 @@ def cmd_create(args) -> None:
             "  Check onshape-to-robot output above for errors."
         )
 
+    if args.attach_to_world is not None:
+        world_base_link = args.attach_to_world
+    else:
+        world_base_link = _prompt_yes_no(
+            "Fix robot to world? (arm/fixed base = yes, mobile chassis = no)"
+        )
+
     _reduce_meshes(workdir / "assets", args.no_reduce)
-    _scaffold_packages(robot, urdf_path, workdir / "assets", out_dir)
+    _scaffold_packages(robot, urdf_path, workdir / "assets", out_dir, world_base_link)
 
     # Register in robots.json
     registry = load_robots_json()
     registry = [e for e in registry if e["name"] != robot]
-    registry.append({"name": robot, "url": args.onshape_url})
+    registry.append({"name": robot, "url": args.onshape_url, "world_base_link": world_base_link})
     save_robots_json(registry)
-    info(f"Registered '{robot}' in robots.json")
+    info(f"Registered '{robot}' in robots.json (world_base_link={world_base_link})")
 
 
 def cmd_local(args) -> None:
@@ -108,16 +128,23 @@ def cmd_local(args) -> None:
 
     info(f"Creating packages for robot: {robot} (local mode)")
 
+    if args.attach_to_world is not None:
+        world_base_link = args.attach_to_world
+    else:
+        world_base_link = _prompt_yes_no(
+            "Fix robot to world? (arm/fixed base = yes, mobile chassis = no)"
+        )
+
     if not args.no_reduce and meshes_src.exists() and any(meshes_src.iterdir()):
         with tempfile.TemporaryDirectory() as tmp:
             reduced = Path(tmp) / "assets"
             shutil.copytree(meshes_src, reduced)
             _reduce_meshes(reduced, no_reduce=False)
-            _scaffold_packages(robot, urdf_path, reduced, out_dir)
+            _scaffold_packages(robot, urdf_path, reduced, out_dir, world_base_link)
     else:
         if args.no_reduce:
             info("Skipping STL reduction (--no-reduce)")
-        _scaffold_packages(robot, urdf_path, meshes_src, out_dir)
+        _scaffold_packages(robot, urdf_path, meshes_src, out_dir, world_base_link)
 
 
 def cmd_raw(args) -> None:
@@ -193,10 +220,13 @@ def cmd_update(args) -> None:
     elif not any(exported_meshes_src.iterdir()):
         warn(f"Meshes directory {exported_meshes_src} is empty")
 
+    world_base_link = entry.get("world_base_link", False)
+    info(f"world_base_link={world_base_link} (from robots.json)")
+
     _reduce_meshes(exported_meshes_src, args.no_reduce)
 
     info("Post-processing URDF...")
-    geometry_urdf, _, _, _ = postprocess(exported_urdf_path, robot)
+    geometry_urdf, _, _, _ = postprocess(exported_urdf_path, robot, world_base_link)
 
     info("Updating description package...")
     update_description_pkg(robot, geometry_urdf, exported_meshes_src, out_dir)

--- a/.github/genbot/urdf.py
+++ b/.github/genbot/urdf.py
@@ -113,6 +113,27 @@ def _generate_control_xacro(robot_name: str, joints: list) -> str:
     return "\n".join(lines)
 
 
+def _inject_world_base_link(urdf_text: str) -> str:
+    """Insert a world link and fixed world_to_base_link joint before the first <link> tag."""
+    snippet = (
+        "\n"
+        "  <!-- World base link -->\n"
+        '  <link name="world"/>\n'
+        "\n"
+        '  <joint name="world_to_base_link" type="fixed">\n'
+        '    <parent link="world"/>\n'
+        '    <child link="base_link"/>\n'
+        '    <origin xyz="0 0 0" rpy="0 0 0"/>\n'
+        "  </joint>\n"
+        "\n"
+    )
+    match = re.search(r"<link\b", urdf_text)
+    if match:
+        pos = match.start()
+        return urdf_text[:pos] + snippet + urdf_text[pos:]
+    return urdf_text.replace("</robot>", snippet + "</robot>", 1)
+
+
 def _inject_control_include(urdf_text: str, robot_name: str) -> str:
     """Append xacro:include for control xacro before </robot>"""
     include = (
@@ -136,16 +157,19 @@ def _reindent(text: str, from_spaces: int = 2, to_spaces: int = 4) -> str:
     return "".join(result)
 
 
-def postprocess(raw_urdf_path: str | Path, robot_name: str) -> tuple:
+def postprocess(raw_urdf_path: str | Path, robot_name: str, world_base_link: bool = False) -> tuple:
     """Read raw URDF, apply all transforms.
 
     Returns (geometry_urdf_string, control_xacro_string, joint_list, link_list).
     joint_list items are (name, lower_limit, upper_limit).
+    If world_base_link is True, a fixed world→base_link joint is prepended.
     """
     text = Path(raw_urdf_path).read_text(encoding="utf-8")
     text = _ensure_xacro_ns(text)
     text = _inject_xacro_properties(text, robot_name)
     text = _rewrite_mesh_paths(text)
+    if world_base_link:
+        text = _inject_world_base_link(text)
     links = _extract_links(text)
     joints = _extract_revolute_joints(text)
     control_xacro = _generate_control_xacro(robot_name, joints)

--- a/.github/workflows/genbot.yaml
+++ b/.github/workflows/genbot.yaml
@@ -1,4 +1,4 @@
-name: Generate/Update Robot from OnShape
+name: Create new robot
 
 on:
   workflow_dispatch:
@@ -18,6 +18,10 @@ on:
         description: 'OnShape URL (required for create, ignored for update)'
         required: false
         type: string
+      attach_to_world:
+        description: 'Fix robot to world? (arm/fixed base = true, mobile chassis = false)'
+        required: true
+        type: boolean
 
 jobs:
   generate:
@@ -58,7 +62,8 @@ jobs:
           PYTHONPATH: .github
         run: |
           if [ "${{ inputs.mode }}" = "create" ]; then
-            python -m genbot create "${{ inputs.robot_name }}" "${{ inputs.onshape_url }}"
+            ATTACH_FLAG=$([[ "${{ inputs.attach_to_world }}" == "true" ]] && echo "--attach-to-world" || echo "--no-attach-to-world")
+            python -m genbot create "${{ inputs.robot_name }}" "${{ inputs.onshape_url }}" $ATTACH_FLAG
           else
             python -m genbot update "${{ inputs.robot_name }}"
           fi

--- a/robot-sim/arm_description/meshes/part_1__9.part
+++ b/robot-sim/arm_description/meshes/part_1__9.part
@@ -1,7 +1,7 @@
 {
     "configuration": "default",
     "documentId": "9b05a4dfb79241a5b295b397",
-    "documentMicroversion": "2bc9dd3762ad67613c0ed191",
+    "documentMicroversion": "81d479939ba9beb4bdfc28b0",
     "elementId": "9e8d02f9f5ceca18e283efe0",
     "fullConfiguration": "default",
     "id": "MXqGcbFF466ijTCi3",

--- a/robot-sim/arm_description/urdf/arm.urdf
+++ b/robot-sim/arm_description/urdf/arm.urdf
@@ -7,7 +7,17 @@
     <xacro:arg name="controller_config" default=""/>
 
     <!-- Link base_link -->
-    <link name="base_link">
+
+    <!-- World base link -->
+    <link name="world"/>
+
+    <joint name="world_to_base_link" type="fixed">
+        <parent link="world"/>
+        <child link="base_link"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+    </joint>
+
+<link name="base_link">
         <inertial>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <mass value="1e-09"/>

--- a/robots.json
+++ b/robots.json
@@ -1,6 +1,7 @@
 [
-  {
-    "name": "arm",
-    "url": "https://trickfire.onshape.com/documents/9b05a4dfb79241a5b295b397/w/d00f3086da43b93d9c689413/e/f5729953e1df72ab5053d822"
-  }
+    {
+        "name": "arm",
+        "url": "https://trickfire.onshape.com/documents/9b05a4dfb79241a5b295b397/w/d00f3086da43b93d9c689413/e/f5729953e1df72ab5053d822",
+        "world_base_link": true
+    }
 ]


### PR DESCRIPTION
## Problem

Robots exported from OnShape have no concept of world attachment. Fixed-base robots (arm or other modules etc.) need a world link and a fixed world_to_base_link joint injected into the URDF so they don't funnily tip over in the simulation.

## Solution

`genbot` automatically injects a world attachment during URDF post-processing, with the choice (not all robots want a world baselink) that persists (saved in the robot registry) so re-exports stay consistent, and a CI-friendly flag so the workflow doesn't block on a prompt.