### PR TITLE
Fix node version to fix CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: docs/package-lock.json
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -23,7 +23,7 @@ export default defineConfig({
                 alt: 'TrickFire Robotics Logo',
                 replacesTitle: true,
             },
-            favicon: 'favicon.ico',
+            favicon: '/favicon.ico',
             social: [
                 {
                     icon: 'github',


### PR DESCRIPTION
Bumped `node` version in pages CI because Astro needs 22.