### PR TITLE
Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Gazebo Fortress simulations for TrickFire Robotics robot subsystems, running on 
 
 ## `Documentation`
 
-**Full documentation is at [trickfirerobotics.github.io/gazebo-simulations](https://trickfirerobotics.github.io/gazebo-simulations)**
+**Full documentation is at [trickfirerobotics.com/gazebo-simulations](https://trickfirerobotics.com/gazebo-simulations)**
 
-- [Getting Started](https://trickfirerobotics.github.io/gazebo-simulations/guides/getting-started/) - setup, Dev Container, display, first launch
-- [Running Simulations](https://trickfirerobotics.github.io/gazebo-simulations/guides/running-simulations/) - `launch_sim.sh` usage and flags
-- [Moving Joints](https://trickfirerobotics.github.io/gazebo-simulations/guides/moving-joints/) - Joint GUI and `move_joints` CLI node
-- [Adding a New Robot](https://trickfirerobotics.github.io/gazebo-simulations/guides/adding-robots/) - genbot + OnShape pipeline
-- [Reference](https://trickfirerobotics.github.io/gazebo-simulations/reference/ros-workspace/) - scripts, genbot, launch system, Docker environment in depth
+- [Getting Started](https://trickfirerobotics.com/gazebo-simulations/guides/getting-started/) - setup, Dev Container, display, first launch
+- [Running Simulations](https://trickfirerobotics.com/gazebo-simulations/guides/running-simulations/) - `launch_sim.sh` usage and flags
+- [Moving Joints](https://trickfirerobotics.com/gazebo-simulations/guides/moving-joints/) - Joint GUI and `move_joints` CLI node
+- [Adding a New Robot](https://trickfirerobotics.com/gazebo-simulations/guides/adding-robots/) - genbot + OnShape pipeline
+- [Reference](https://trickfirerobotics.com/gazebo-simulations/reference/ros-workspace/) - scripts, genbot, launch system, Docker environment in depth


### PR DESCRIPTION
Update documentation links in the README from `trickfire.github.io` to `trickfire.com` as I did not know Github will use the organisation domain automatically.