### PR TITLE
Fixed TrickFireBot not having correct auth

### DIFF
--- a/.github/workflows/reencrypt.yml
+++ b/.github/workflows/reencrypt.yml
@@ -15,7 +15,15 @@ jobs:
             contents: write
 
         steps:
+            - uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: "3704720"
+                  private-key: ${{ secrets.TRICKFIREBOT_PRIVATE_KEY }}
+
             - uses: actions/checkout@v4
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Install age
               run: sudo apt-get install -y age


### PR DESCRIPTION
Fixed TrickFireBot using default GitHub push token, so not getting authed corretly, casusing it to not bypass main protection.